### PR TITLE
Fix HTMLSelectElement.remove in IE 11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@ function polyfill() {
         this.parentElement.removeChild(this);
     }
 
+    if (Object.getPrototypeOf(Object.getPrototypeOf(HTMLSelectElement)) === null) {
+        HTMLSelectElement.prototype.remove = Element.prototype.remove;
+    }
+    
     NodeList.prototype.remove = HTMLCollection.prototype.remove = function() {
         for(var i = this.length - 1; i >= 0; i--) {
             if(this[i] && this[i].parentElement) {


### PR DESCRIPTION
Need to support IE 11 (this may also apply to earlier versions) and found out this polyfill doesn't work on HTMLSelectElement as it doesn't have the correct prototype chain.